### PR TITLE
Rewrite README with structured quickstart, project layout, and FOCAS usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,140 @@
 # FocasDemo
 
-​**一步一步教你如何连接 Fanuc 机床，适合新手入门！​**​
+**Fanuc FOCAS 通信示例项目（新手友好）**
 
-本项目提供完整的 Fanuc FOCAS 接口开发示例，帮助初学者快速掌握机床通信的基础操作。  
-包含代码示例、配置说明和常见问题解答，助你轻松上手！
-
----
-
-## 📌 项目简介
-
-- 从零开始配置 Fanuc FOCAS 开发环境
-- 分步骤演示连接机床的完整流程
-- 提供 C# 示例代码
-- 解决常见连接错误和调试技巧
-- 软件界面
-<img src="https://github.com/user-attachments/assets/6b491777-8f0b-4ac8-8b09-6c56166134b7" width="1000">
----
-
-## 🎥 视频教程
-
-​**详细操作请观看 B 站视频讲解**​：  
-[【B站搜索：cherish陆工】](https://space.bilibili.com/38361468)  
-或扫描下方二维码直达：
-
-<img src="https://github.com/user-attachments/assets/63bdfedd-24b1-453e-8397-60c791a2d91f" width="500">
+本仓库用于演示如何通过 C# 调用 Fanuc FOCAS 接口与机床通信，包含：
+- WinForms 图形化示例（操作演示更直观）
+- .NET 6 控制台示例（最小连接流程）
+- 常见读写接口示例（诊断、宏变量、参数、时间、操作履历等）
 
 ---
 
-## 🛠️ 快速开始
+## 项目结构
 
-### 前置条件
-1. Fanuc 机床支持 FOCAS 协议
-2. 安装 FOCAS 驱动（如 `Fwlib32.dll`）
-3. 确保机床与电脑在同一网络
-
-### 基础连接示例（C#）
-```csharp
-   private void btn_Connect_Click(object sender, EventArgs e)
-   {
-       var prot = ushort.Parse(this.txt_Port.Text.Trim());
-       _ret = Focas1.cnc_allclibhndl3(this.txt_IP.Text.Trim(), prot, 10, out _flibhndl);
-       if(_ret == 0)
-       {
-           Print("Connect Success");
-
-           _isConnect =true;
-       }
-       else
-       {
-           Print("Connect Fail");
-           _isConnect = false;
-       }
-   }
-
-   private void btn_DisConnect_Click(object sender, EventArgs e)
-   {
-       _ret = Focas1.cnc_freelibhndl(_flibhndl);
-       if (_ret == 0)
-       {
-           Print("DisConnect Success");
-           _isConnect = false;
-       }
-       else
-       {
-           Print("DisConnect Fail");
-           _isConnect = false;
-       }
-   }
+```text
+FocasDemo/
+├── Cherish.IOCNC.Focas/          # .NET Framework 4.7.2 WinForms 示例
+│   ├── Form1.cs                  # 主要示例逻辑（连接、读写、日志）
+│   ├── Form1.Designer.cs         # 界面定义（按钮、分组、输入项）
+│   ├── fwlib32.cs                # FOCAS C# 封装（结构体 + DllImport）
+│   └── Program.cs                # WinForms 入口
+├── Focas.linux/                  # .NET 6 控制台示例
+│   ├── Program.cs                # 最小流程：初始化、连接、读取位置、退出
+│   └── fwlib32.cs                # Linux 项目的 FOCAS 封装
+├── packages/                     # NuGet 依赖（当前含 Obfuscar）
+└── Cherish.IOCNC.Focas.sln       # 解决方案
 ```
 
-## 💰 打赏支持
-如果这个项目对你有帮助，刚好你也手头宽裕，欢迎打赏支持作者，量力而行！
+---
 
-| <img src="https://github.com/user-attachments/assets/f8f134ec-22bb-4f5e-aaf1-ec605a26a1b5" width="200"> | <img src="https://github.com/user-attachments/assets/65e245ed-9cc3-440b-9f8e-570aa94b4c32" width="200"> |
+## 环境准备
 
-感谢你的支持！❤️
+1. Fanuc 机床支持 FOCAS 协议。
+2. 机床与开发机在同一网络，确保 IP/端口可达（默认端口常见为 `8193`）。
+3. 准备 FOCAS 动态库（例如 `FWLIB32.dll` 等对应库文件）。
+4. Windows 项目建议使用 Visual Studio 2022 打开 `Cherish.IOCNC.Focas.sln`。
+
+> 提示：仓库中已包含部分 dll 与示例配置，但实际部署需以你的机床型号与 FANUC 官方文档为准。
+
+---
+
+## 快速开始（推荐路径）
+
+### 1）先跑通 WinForms 示例（推荐新手）
+
+1. 打开 `Cherish.IOCNC.Focas.sln`。
+2. 启动项目 `Cherish.IOCNC.Focas`。
+3. 在界面中填入机床 IP 与端口（默认有 `127.0.0.1` 和 `8193` 示例值）。
+4. 点击 **Connect**。
+5. 在日志窗口查看 `Connect Success / Connect Fail`。
+6. 完成后点击 **DisConnect** 释放句柄。
+
+### 2）再看 .NET 6 控制台最小流程
+
+`Focas.linux/Program.cs` 演示了典型生命周期：
+- `cnc_startupprocess` 初始化
+- `cnc_allclibhndl3` 连接
+- `cnc_rdposition` 读取位置
+- `cnc_exitthread` / `cnc_exitprocess` 清理
+
+---
+
+## 核心调用模式（务必掌握）
+
+几乎所有 FOCAS 调用都遵循同一个模式：
+
+1. 连接获取句柄（`cnc_allclibhndl3`）
+2. 调用目标 API（`cnc_xxx`）
+3. 判断返回码（`EW_OK` 为成功）
+4. 断开连接并释放句柄（`cnc_freelibhndl`）
+
+参考示例：
+
+```csharp
+var prot = ushort.Parse(this.txt_Port.Text.Trim());
+_ret = Focas1.cnc_allclibhndl3(this.txt_IP.Text.Trim(), prot, 10, out _flibhndl);
+if (_ret == 0)
+{
+    Print("Connect Success");
+    _isConnect = true;
+}
+else
+{
+    Print("Connect Fail");
+    _isConnect = false;
+}
+```
+
+---
+
+## 已覆盖的主要示例功能
+
+WinForms 示例中包含以下典型功能分组：
+
+- 报警信息读取与乱码处理（按机床语言选择编码）
+- 诊断号读取
+- 宏变量读取
+- 参数读写
+- 时间参数读取/设置
+- 操作履历读取
+
+建议学习顺序：
+1. 连接/断开
+2. 读取类接口（诊断、宏变量、时间）
+3. 写入类接口（参数、系统时间）
+4. 履历/报警等复杂结构
+
+---
+
+## 常见问题（FAQ）
+
+### 1. 连接失败怎么办？
+- 检查机床 IP 与端口。
+- 确认网络互通（同网段、路由、防火墙）。
+- 核对机床侧 FOCAS 相关参数和授权。
+- 确认使用了正确版本的 FOCAS 库。
+
+### 2. 报警信息乱码怎么办？
+- 不要直接用系统默认编码。
+- 先读取机床语言参数，再选择对应编码（如 ASCII / Shift-JIS / GB2312）。
+
+### 3. 为什么同一个接口在不同机床表现不一致？
+- 不同系统版本、机床选项、轴数、功能包会导致结构体字段和可用功能差异。
+- 实际项目请严格对照 FANUC 官方接口文档和机床手册。
+
+---
+
+## 学习建议（给新人）
+
+- 先理解 `fwlib32.cs` 的错误码、结构体和 `DllImport` 映射关系。
+- 再阅读 `Form1.cs` 里每个按钮事件，建立“一个按钮 = 一个接口场景”的思维。
+- 给每个接口记录 4 件事：输入参数、length 计算、返回码、输出结构。
+- 最后再做工程化重构：把事件中的通信逻辑抽到 service 层。
+
+---
+
+## 参考与支持
+
+- B 站： [cherish陆工](https://space.bilibili.com/38361468)
+- 如本项目对你有帮助，欢迎 Star 支持。
+


### PR DESCRIPTION
### Motivation
- Clarify and expand the README to better guide newcomers on using C# with Fanuc FOCAS, covering both WinForms and .NET 6 examples. 
- Provide explicit project structure, environment prerequisites, and a step-by-step quickstart to reduce setup friction. 
- Consolidate core API usage patterns, example snippets, and common troubleshooting into a single, more usable document.

### Description
- Rewrote the README into structured sections including `Project Structure`, `Environment Preparation`, `Quick Start`, `Core Calling Mode`, `Examples`, `FAQ`, and `Learning Suggestions`.
- Added a repository tree block showing `Cherish.IOCNC.Focas` WinForms example and `Focas.linux` .NET 6 console sample and highlighted key files like `Form1.cs`, `Program.cs`, and `fwlib32.cs`.
- Provided step-by-step instructions for running the WinForms sample via `Cherish.IOCNC.Focas.sln` and included the typical FOCAS lifecycle calls such as `cnc_allclibhndl3`, `cnc_rdposition`, and `cnc_exitprocess`.
- Replaced prior embedded video/donation emphasis with concise links and practical guidance, added FAQ entries and learning suggestions for working with `fwlib32.cs` and error/encoding handling.

### Testing
- This is a documentation-only change, so no automated code tests were required or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b024efb8948321b2f26f074c155064)